### PR TITLE
Add Proposal Field Guide to repository

### DIFF
--- a/proposal-field-guide/README.md
+++ b/proposal-field-guide/README.md
@@ -1,0 +1,58 @@
+# The Proposal Field Guide
+
+A practical reference for capture, writing, review, and submission on federal proposals for small business contractors.
+
+Free. No form. No email capture. Take it or leave it.
+
+## What's inside
+
+Ten chapters and a working appendix covering the full federal proposal lifecycle:
+
+1. The proposal lifecycle
+2. Roles and team sizing
+3. Pre-RFP intelligence and capture
+4. Shred discipline: compliance matrix and annotated outline
+5. Win themes and customer-first writing
+6. Graphics that earn their place
+7. Color team reviews
+8. AI in proposal writing: keeping a human voice
+9. Production, QC, and submission
+10. Debrief and lessons learned
+
+The appendix includes templates and checklists for compliance matrices, win themes, Pink/Red/White Glove reviews, and a glossary of federal acquisition terms.
+
+## Who it's for
+
+The owner-operator who writes their own proposals between client deliverables. The capture manager wearing three hats. The proposal manager who joined a small business after a stint at a large prime and now has half the resources and twice the responsibility.
+
+It assumes federal procurement context and one to five people on the proposal team. It does not assume you have a proposal shop, a graphics team, or a senior reviewer on retainer.
+
+## How to use it
+
+Read the guide on GitHub directly: [Proposal-Field-Guide.md](Proposal-Field-Guide.md)
+
+Or clone the repo and read it locally:
+
+```
+git clone https://github.com/vagimeli/govcon-proposal-field-guide.git
+```
+
+## Feedback
+
+Found something useful? Found something wrong? Open an Issue on this repo. I read them.
+
+## License
+
+This guide is shared under [Creative Commons Attribution 4.0 International (CC BY 4.0)](LICENSE).
+
+You can use it, share it, adapt it, and apply it to your own work, including for commercial purposes. The only requirement is attribution:
+
+> Melissa Vagi, CF APMP, Write-Brained Editorial Services, [www.writebrainedits.com](https://www.writebrainedits.com)
+
+## About the author
+
+Melissa Vagi, CF APMP, is the founder of Write-Brained Editorial Services, a Denver-based consultancy specializing in federal proposal development, digital accessibility compliance, and AI workflow automation. Write-Brained is a WOSB and EDWOSB certified small business serving government agencies, technology companies, and higher education institutions.
+
+She brings 15 years of expertise across federal proposal writing, Section 508 and WCAG remediation, and agentic AI system design. Her credentials include CF APMP, IAPP AIGP (in progress), DHS Trusted Tester (in progress), AWS AI Practitioner, and AWS Cloud Practitioner. She is also the creator of the Government Accessibility Audit Prompt Kit.
+
+If you want help with a specific opportunity, find her at [www.writebrainedits.com](https://www.writebrainedits.com).


### PR DESCRIPTION
Added a comprehensive guide for federal proposals, including chapters on the proposal lifecycle, roles, compliance, and more.